### PR TITLE
Update to Climate entity and Require HA 0.110

### DIFF
--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -4,7 +4,7 @@ import pprint
 
 import voluptuous as vol
 
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     CURRENT_HVAC_COOL,
@@ -108,7 +108,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities(devices)
 
 
-class KumoThermostat(ClimateDevice):
+class KumoThermostat(ClimateEntity):
     """Representation of a Kumo Thermostat device."""
 
     # pylint: disable=C0415, R0902, R0904

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 { "name": "Mitsubishi Kumo Cloud",
   "render_readme": true,
   "domains": ["climate"],
-  "homeassistant": "0.96.0",
+  "homeassistant": "0.110.0",
   "iot_class": "local_poll"
 }


### PR DESCRIPTION
HA 0.110 was released this morning. I have updated the requirement to HA 0.110 so that users that did not update can stay on the older version and anyone that updates can use the new version with ClimateEntity