### PR TITLE
fix reference to confirm step instead of request_ips step

### DIFF
--- a/custom_components/kumo/config_flow.py
+++ b/custom_components/kumo/config_flow.py
@@ -157,7 +157,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="request_ips",
             data_schema=vol.Schema(data_schema),
-            description_placeholders=self.user_account_setup,
+            description_placeholders=self.user_account_setup
         )
 
     @staticmethod


### PR DESCRIPTION
I believe this is the cause of the issue beta users are having in config flow. There is a reference to a step named "confirm" which was changed to "request_ips" for clarity as suggested by @dlarrick 