### PR TITLE
feat: update to add kumo station outdoor temperature sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Mitubishi Kumo Cloud (Kumo for short) is a custom component for Home Assistant t
 - Implements standard Home Assistant [`climate`](https://www.home-assistant.io/integrations/climate/) entities.
 - Supports reading and setting the mode (heat/cool/etc.), setpoint, fan speed, and vane swing.
 - Supports fully local control, except for initial setup. (See `prefer_cache` in Configuration for details.)
+- Supports displaying Outdoor Temperature for Kumo Station
+- Supports displaying WiFi RSSI of each unit(disabled by default)
 
 ## Installation
 
-You can install Kumo in one of two ways. 
+You can install Kumo in one of two ways.
 
-- **Automatic Installation.** Kumo is available in the HACS default store. Search for "Kumo" in the Integrations panel, and then click the **Mitsubishi Kumo Cloud** item in the results. Click the Install link, and then restart Home Assistant. 
+- **Automatic Installation.** Kumo is available in the HACS default store. Search for "Kumo" in the Integrations panel, and then click the **Mitsubishi Kumo Cloud** item in the results. Click the Install link, and then restart Home Assistant.
 - **Manual Installation.** To control your installation yourself, download the hass-kumo repo, and then copy the `custom_components/kumo` directory into a corresponding `custom_components/kumo` within your Home Assistant configuration directory. Then restart Home Assistant.
 
 We recommend using the HACS installation method, which makes future updates to Kumo easy to track and install. Click the HACS badge above for details on installing and using HACS.
@@ -39,7 +41,7 @@ kumo:
 
 Add the referenced secrets to your secrets.yaml.
 
-- `prefer_cache`, if present, controls whether to contact the KumoCloud servers on startup, or to prefer locally cached info on how to communicate with the indoor units. Default is `false`, to accommodate changing unit availability or DHCP leases. If your configuration is static (including the units' IP addresses on your LAN), it's safe to set this to `true`. This will allow you to control your system even if KumoCloud or your Internet connection suffer an outage. 
+- `prefer_cache`, if present, controls whether to contact the KumoCloud servers on startup, or to prefer locally cached info on how to communicate with the indoor units. Default is `false`, to accommodate changing unit availability or DHCP leases. If your configuration is static (including the units' IP addresses on your LAN), it's safe to set this to `true`. This will allow you to control your system even if KumoCloud or your Internet connection suffer an outage.
 - `connect_timeout` and `response_timeout`, if present, control network timeouts for each command or status poll from the indoor unit(s). Increase these numbers if you see frequent log messages about timeouts. Decrease these numbers to improve overall HA responsivness if you anticipate your units being offline.
 
 ### IP Addresses
@@ -50,14 +52,14 @@ In some cases, Kumo is unable to retrieve the indoor units' addresses from the K
 
 ## Home Assistant Entities and Control
 
-Each indoor unit appears as a separate [`climate`](https://www.home-assistant.io/integrations/climate/) entity in Home Assistant. Entity names are derived from the name you created for the unit in KumoCloud. For example, `climate.bedroom` or `climate.living_room`. 
+Each indoor unit appears as a separate [`climate`](https://www.home-assistant.io/integrations/climate/) entity in Home Assistant. Entity names are derived from the name you created for the unit in KumoCloud. For example, `climate.bedroom` or `climate.living_room`.
 
 Entity attributes can tell you more about the current state of the indoor unit, as well as the unit's capabilities. Attributes may include the following:
 
 - `hvac_modes`: The different modes of operation supported by the unit. For example: `off, cool, dry, heat, fan_only`.
 - `min_temp`: The minimum temperature the unit can be set to. For example, `45`.
 - `max_temp`: The maximum temperature the unit can be set to: For example, `95`.
-- `fan_modes`: The different modes supported for the fan. This corresponds to fan speed, and noise. For example: `superQuiet, quiet, low, powerful, superPowerful, auto`. 
+- `fan_modes`: The different modes supported for the fan. This corresponds to fan speed, and noise. For example: `superQuiet, quiet, low, powerful, superPowerful, auto`.
 - `swing_modes`: The different modes supported for the fan vanes. For example: `horizontal, midhorizontal, midpoint, midvertical, auto, swing`.
 - `current_temperature`: The current ambient temperature, as sensed by the indoor unit. For example, `73`.
 - `temperature`: The target temperature. For example, `77`.

--- a/custom_components/kumo/__init__.py
+++ b/custom_components/kumo/__init__.py
@@ -1,16 +1,16 @@
 """Support for Mitsubishi KumoCloud devices."""
-import asyncio
 import logging
+from typing import Optional
 
 import homeassistant.helpers.config_validation as cv
 import pykumo
 import voluptuous as vol
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.json import load_json, save_json
 
+from .coordinator import KumoDataUpdateCoordinator
 from .const import (
     CONF_CONNECT_TIMEOUT,
     CONF_PREFER_CACHE,
@@ -18,6 +18,8 @@ from .const import (
     DOMAIN,
     KUMO_CONFIG_CACHE,
     KUMO_DATA,
+    KUMO_DATA_COORDINATORS,
+    PLATFORMS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,7 +41,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-class KumoData:
+class KumoCloudSettings:
     """Hold object representing KumoCloud account."""
 
     def __init__(self, account, domain_config, domain_options):
@@ -65,157 +67,70 @@ class KumoData:
         """Retrieve raw JSON config from account."""
         return self._account.get_raw_json()
 
-
-def setup_kumo(hass, config):
-    """Set up the Kumo indoor units."""
-    hass.async_create_task(async_load_platform(hass, "climate", DOMAIN, {}, config))
-    hass.async_add_job(hass.config_entries.async_forward_entry_setup(config, "climate"))
-    hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, {}, config))
-    hass.async_add_job(hass.config_entries.async_forward_entry_setup(config, "sensor"))
-
-
-async def async_setup(hass, config):
-    """Set up the Kumo Cloud devices. Will create climate and sensor components to support devices listed on the provided Kumo Cloud account."""
-    if DOMAIN not in config:
-        return True
-    # pylint: disable=C0415
-    username = config[DOMAIN].get(CONF_USERNAME)
-    password = config[DOMAIN].get(CONF_PASSWORD)
-    prefer_cache = config[DOMAIN].get(CONF_PREFER_CACHE)
-    domain_options = {
-        "connect_timeout": config[DOMAIN].get(CONF_CONNECT_TIMEOUT),
-        "response_timeout": config[DOMAIN].get(CONF_RESPONSE_TIMEOUT),
-    }
-
-    # Read config from either remote KumoCloud server or
-    # cached JSON.
-    cached_json = {}
-    success = False
-    if prefer_cache:
-        # Try to load from cache
-        cached_json = await hass.async_add_executor_job(
-            load_json, hass.config.path(KUMO_CONFIG_CACHE)
-        ) or {"fetched": False}
-        account = pykumo.KumoCloudAccount(username, password, kumo_dict=cached_json)
-    else:
-        # Try to load from server
-        account = pykumo.KumoCloudAccount(username, password)
-    setup_success = await hass.async_add_executor_job(account.try_setup)
-    if setup_success:
-        if prefer_cache:
-            _LOGGER.info("Loaded config from local cache")
-            success = True
-        else:
-            await hass.async_add_executor_job(
-                save_json, hass.config.path(KUMO_CONFIG_CACHE), account.get_raw_json()
-            )
-            _LOGGER.info("Loaded config from KumoCloud server")
-            success = True
-    else:
-        # Fall back
-        if prefer_cache:
-            # Try to load from server
-            account = pykumo.KumoCloudAccount(username, password)
-        else:
-            # Try to load from cache
-            cached_json = await hass.async_add_executor_job(
-                load_json, hass.config.path(KUMO_CONFIG_CACHE)
-            ) or {"fetched": False}
-            account = pykumo.KumoCloudAccount(username, password, kumo_dict=cached_json)
-        setup_success = await hass.async_add_executor_job(account.try_setup)
-        if setup_success:
-            if prefer_cache:
-                await hass.async_add_executor_job(
-                    save_json,
-                    hass.config.path(KUMO_CONFIG_CACHE),
-                    account.get_raw_json(),
-                )
-                _LOGGER.info("Loaded config from KumoCloud server as fallback")
-                success = True
-            else:
-                _LOGGER.info("Loaded config from local cache as fallback")
-                success = True
-
-    if success:
-        hass.data[KUMO_DATA] = KumoData(account, config[DOMAIN], domain_options)
-        setup_kumo(hass, config)
-        return True
-
-    _LOGGER.warning("Could not load config from KumoCloud server or cache")
-    return False
-
-
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
-    """Setup Entry"""
+    """Setup Kumo Entry"""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN].setdefault(entry.entry_id, {})
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
     prefer_cache = entry.data.get(CONF_PREFER_CACHE)
-    # Read config from either remote KumoCloud server or
-    # cached JSON.
-    cached_json = {}
-    success = False
+
+    account = await async_kumo_setup(hass, prefer_cache, username, password)
+
+    if not account:
+        # Attempt setup again, but flip the prefer_cache flag
+        account = await async_kumo_setup(hass, not prefer_cache, username, password)
+
+    if account:
+        hass.data[DOMAIN][entry.entry_id][KUMO_DATA] = KumoCloudSettings(account, entry.data, entry.options)
+
+        # Create a data coordinator for each Kumo device
+        hass.data[DOMAIN][entry.entry_id].setdefault(KUMO_DATA_COORDINATORS, {})
+        coordinators = hass.data[DOMAIN][entry.entry_id][KUMO_DATA_COORDINATORS]
+        connect_timeout = float(
+            entry.options.get(CONF_CONNECT_TIMEOUT, "1.2")
+        )
+        response_timeout = float(
+            entry.options.get(CONF_RESPONSE_TIMEOUT, "8")
+        )
+        timeouts = (connect_timeout, response_timeout)
+        pykumos = await hass.async_add_executor_job(account.make_pykumos, timeouts, True)
+        for device in pykumos.values():
+            if device.get_serial() not in coordinators:
+                coordinators[device.get_serial()] = KumoDataUpdateCoordinator(hass, device)
+
+        hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+        return True
+
+    _LOGGER.warning("Could not load config from KumoCloud server or cache")
+    return False
+
+async def async_kumo_setup(hass: HomeAssistantType, prefer_cache: bool, username: str, password: str) -> Optional[pykumo.KumoCloudAccount]:
+    """Attempt to load data from cache or Kumo Cloud"""
     if prefer_cache:
-        # Try to load from cache
         cached_json = await hass.async_add_executor_job(
             load_json, hass.config.path(KUMO_CONFIG_CACHE)
         ) or {"fetched": False}
         account = pykumo.KumoCloudAccount(username, password, kumo_dict=cached_json)
     else:
-        # Try to load from server
         account = pykumo.KumoCloudAccount(username, password)
+
     setup_success = await hass.async_add_executor_job(account.try_setup)
+
     if setup_success:
         if prefer_cache:
             _LOGGER.info("Loaded config from local cache")
-            success = True
         else:
             await hass.async_add_executor_job(
                 save_json, hass.config.path(KUMO_CONFIG_CACHE), account.get_raw_json()
             )
             _LOGGER.info("Loaded config from KumoCloud server")
-            success = True
-    else:
-        # Fall back
-        if prefer_cache:
-            # Try to load from server
-            account = pykumo.KumoCloudAccount(username, password)
-        else:
-            # Try to load from cache
-            cached_json = await hass.async_add_executor_job(
-                load_json, hass.config.path(KUMO_CONFIG_CACHE)
-            ) or {"fetched": False}
-            account = pykumo.KumoCloudAccount(username, password, kumo_dict=cached_json)
-        setup_success = await hass.async_add_executor_job(account.try_setup)
-        if setup_success:
-            if prefer_cache:
-                await hass.async_add_executor_job(
-                    save_json,
-                    hass.config.path(KUMO_CONFIG_CACHE),
-                    account.get_raw_json(),
-                )
-                _LOGGER.info("Loaded config from KumoCloud server as fallback")
-                success = True
-            else:
-                _LOGGER.info("Loaded config from local cache as fallback")
-                success = True
-    if success:
-        data = KumoData(account, entry.data, entry.options)
-        hass.data[DOMAIN] = data
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, "climate")
-        )
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, "sensor")
-        )
-        return True
-    _LOGGER.warning("Could not load config from KumoCloud server or cache")
-    return False
 
+        return account
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Unload Entry"""
-    hass.data.pop(DOMAIN)
-    tasks = []
-    tasks.append(hass.config_entries.async_forward_entry_unload(entry, "climate"))
-    tasks.append(hass.config_entries.async_forward_entry_unload(entry, "sensor"))
-    return all(await asyncio.gather(*tasks))
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/kumo/__init__.py
+++ b/custom_components/kumo/__init__.py
@@ -70,6 +70,8 @@ def setup_kumo(hass, config):
     """Set up the Kumo indoor units."""
     hass.async_create_task(async_load_platform(hass, "climate", DOMAIN, {}, config))
     hass.async_add_job(hass.config_entries.async_forward_entry_setup(config, "climate"))
+    hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, {}, config))
+    hass.async_add_job(hass.config_entries.async_forward_entry_setup(config, "sensor"))
 
 
 async def async_setup(hass, config):
@@ -202,6 +204,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, "climate")
         )
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, "sensor")
+        )
         return True
     _LOGGER.warning("Could not load config from KumoCloud server or cache")
     return False
@@ -212,4 +217,5 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
     hass.data.pop(DOMAIN)
     tasks = []
     tasks.append(hass.config_entries.async_forward_entry_unload(entry, "climate"))
+    tasks.append(hass.config_entries.async_forward_entry_unload(entry, "sensor"))
     return all(await asyncio.gather(*tasks))

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -121,7 +121,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         response_timeout = float(
             data.get_domain_options().get(CONF_RESPONSE_TIMEOUT, "8")
         )
-        kumo_api = pykumo.PyKumo(
+        kumo_api = pykumo.PyKumoIndoorUnit(
             name, address, credentials, (connect_timeout, response_timeout)
         )
         success = await hass.async_add_executor_job(kumo_api.update_status)

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -401,7 +401,7 @@ class KumoThermostat(CoordinatedKumoEntitty, ClimateEntity):
         self._defrost = defrost
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the device."""
         attr = {}
         if self._battery_percent is not None:

--- a/custom_components/kumo/const.py
+++ b/custom_components/kumo/const.py
@@ -1,8 +1,25 @@
 """Constants for the Kumo integration."""
+
+from datetime import timedelta
+from typing import Final
+
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+
 DEFAULT_NAME = "Kumo"
 DOMAIN = "kumo"
-KUMO_DATA = "kumo_data"
+KUMO_DATA = "data"
+KUMO_DATA_COORDINATORS = "coordinators"
 KUMO_CONFIG_CACHE = "kumo_cache.json"
 CONF_PREFER_CACHE = "prefer_cache"
 CONF_CONNECT_TIMEOUT = "connect_timeout"
 CONF_RESPONSE_TIMEOUT = "response_timeout"
+MAX_AVAILABILITY_TRIES = 3 # How many times we will attempt to update from a kumo before marking it unavailable
+
+PLATFORMS: Final = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
+
+# This is the new way of important platforms, but isn't public yet
+# from homeassistant.const import Platform
+# PLATFORMS: Final = [Platform.CLIMATE, Platform.SENSOR]
+
+SCAN_INTERVAL = timedelta(seconds=60)

--- a/custom_components/kumo/coordinator.py
+++ b/custom_components/kumo/coordinator.py
@@ -1,0 +1,67 @@
+"""Coordinator to gather data for the Kumo integration"""
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
+                                                      UpdateFailed)
+from pykumo import PyKumoBase
+
+from .const import SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+MAX_AVAILABILITY_TRIES = 3
+
+T = TypeVar("T")
+
+
+class KumoDataUpdateCoordinator(DataUpdateCoordinator):
+    """DataUpdateCoordinator to gather data for a specific Kumo device."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device: PyKumoBase,
+    ) -> None:
+        """Initialize DataUpdateCoordinator to gather data for specific Kumo device."""
+        self.device = device
+        self._available = False
+        self._unavailable_count = 0
+        self._additional_update_methods = []
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"kumo_{device.get_serial()}",
+            update_interval=SCAN_INTERVAL,
+        )
+
+    def get_device(self) -> PyKumoBase:
+        return self.device
+
+    def get_available(self) -> bool:
+        return self._available
+
+    def add_update_method(self, update_method: Callable[[], Awaitable[T]]) -> None:
+        """Register update methods that will be called after updating status"""
+        self._additional_update_methods.append(update_method)
+
+    async def _async_update_data(self) -> None:
+        """Fetch data from Kumo device."""
+        success = await self.hass.async_add_executor_job(self.device.update_status)
+        self._update_availability(success)
+        if success:
+            for update_method in self._additional_update_methods:
+                await update_method()
+        else:
+            raise UpdateFailed(f"Failed to update Kumo device: {self.device.get_name()}")
+
+    def _update_availability(self, success: bool) -> None:
+        if success:
+            self._available = True
+            self._unavailable_count = 0
+        else:
+            self._unavailable_count += 1
+            if self._unavailable_count >= MAX_AVAILABILITY_TRIES:
+                self._available = False

--- a/custom_components/kumo/entity.py
+++ b/custom_components/kumo/entity.py
@@ -1,0 +1,49 @@
+"""Entities for The Internet Printing Protocol (IPP) integration."""
+from __future__ import annotations
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KumoDataUpdateCoordinator
+
+
+class CoordinatedKumoEntitty(CoordinatorEntity):
+    """Defines a base Kumo entity."""
+
+    def __init__(
+        self,
+        coordinator: KumoDataUpdateCoordinator
+    ) -> None:
+        """Initialize the Kumo entity."""
+        super().__init__(coordinator)
+        self._coordinator = coordinator
+        self._pykumo = coordinator.get_device()
+        self._identifier = self._pykumo.get_serial()
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device information about this IPP device."""
+        if self._identifier is None:
+            return None
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._identifier)},
+            manufacturer="Mitsubishi",
+            name=self._pykumo.get_name(),
+        )
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def available(self):
+        """Return whether Home Assistant is able to read the state and control the underlying device."""
+        return self._coordinator.get_available()
+
+    @property
+    def name(self):
+        """Return the name of the thermostat, if any."""
+        return self._name

--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "https://github.com/dlarrick/hass-kumo",
     "dependencies": [],
     "codeowners": [ "@dlarrick" ],
-    "requirements": ["pykumo==0.1.12"],
+    "requirements": ["pykumo==0.2.0"],
     "version": "0.2.7",
     "homeassistant": "0.96.0"
 }

--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "https://github.com/dlarrick/hass-kumo",
     "dependencies": [],
     "codeowners": [ "@dlarrick" ],
-    "requirements": ["pykumo==0.2.0"],
+    "requirements": ["pykumo==0.2.1"],
     "version": "0.2.7",
     "homeassistant": "0.96.0"
 }

--- a/custom_components/kumo/sensor.py
+++ b/custom_components/kumo/sensor.py
@@ -1,0 +1,196 @@
+"""HomeAssistant sensor component for Kumo Station Device."""
+import logging
+import pprint
+from datetime import timedelta
+
+import pykumo
+import voluptuous as vol
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+
+from .const import DOMAIN
+
+try:
+    from homeassistant.components.sensor import SensorEntity
+except ImportError:
+    from homeassistant.components.sensor import SensorDevice as SensorEntity
+
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, CONF_SCAN_INTERVAL
+
+from . import CONF_CONNECT_TIMEOUT, CONF_RESPONSE_TIMEOUT, KUMO_DATA
+
+_LOGGER = logging.getLogger(__name__)
+__PLATFORM_IS_SET_UP = False
+
+CONF_NAME = "name"
+CONF_ADDRESS = "address"
+CONF_CONFIG = "config"
+
+ATTR_RSSI = "rssi"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_ADDRESS): cv.string,
+        vol.Required(CONF_CONFIG): cv.string,
+    }
+)
+
+MAX_SETUP_TRIES = 10
+MAX_AVAILABILITY_TRIES = 3
+
+SCAN_INTERVAL = timedelta(seconds=60)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Kumo Stations."""
+    data = hass.data[DOMAIN]
+    data._setup_tries += 1
+    if data._setup_tries > MAX_SETUP_TRIES:
+        raise HomeAssistantError("Giving up trying to set up Kumo")
+
+    devices = []
+    units = await hass.async_add_executor_job(data.get_account().get_kumo_stations)
+    for unit in units:
+        name = data.get_account().get_name(unit)
+        address = data.get_account().get_address(unit)
+        credentials = data.get_account().get_credentials(unit)
+        connect_timeout = float(
+            data.get_domain_options().get(CONF_CONNECT_TIMEOUT, "1.2")
+        )
+        response_timeout = float(
+            data.get_domain_options().get(CONF_RESPONSE_TIMEOUT, "8")
+        )
+        kumo_api = pykumo.PyKumoStation(
+            name, address, credentials, (connect_timeout, response_timeout)
+        )
+        success = await hass.async_add_executor_job(kumo_api.update_status)
+        if not success:
+            _LOGGER.warning("Kumo %s could not be set up", name)
+            continue
+        kumo_station = KumoStationOutdoorTemperature(kumo_api, unit)
+        await hass.async_add_executor_job(kumo_station.update)
+        devices.append(kumo_station)
+        _LOGGER.debug("Kumo adding entity: %s", name)
+
+    if devices:
+        async_add_entities(devices, True)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up Kumo Stations. Run Once"""
+    global __PLATFORM_IS_SET_UP
+    if __PLATFORM_IS_SET_UP:
+        return
+    __PLATFORM_IS_SET_UP = True
+
+    data = hass.data[KUMO_DATA]
+    data._setup_tries += 1
+    if data._setup_tries > MAX_SETUP_TRIES:
+        raise HomeAssistantError("Giving up trying to set up Kumo Stations")
+
+    devices = []
+    units = data.get_account().get_kumo_stations()
+    for unit in units:
+        name = data.get_account().get_name(unit)
+        address = data.get_account().get_address(unit)
+        credentials = data.get_account().get_credentials(unit)
+        if data.get_domain_options().get(CONF_CONNECT_TIMEOUT) is None:
+            connect_timeout = 1.2
+        else:
+            connect_timeout = float(
+                data.get_domain_options().get(CONF_CONNECT_TIMEOUT, "1.2")
+            )
+        if data.get_domain_options().get(CONF_RESPONSE_TIMEOUT) is None:
+            response_timeout = 8.0
+        else:
+            response_timeout = float(
+                data.get_domain_options().get(CONF_RESPONSE_TIMEOUT, "8")
+            )
+        kumo_api = pykumo.PyKumoStation(
+            name, address, credentials, (connect_timeout, response_timeout)
+        )
+        success = await hass.async_add_executor_job(kumo_api.update_status)
+        if not success:
+            _LOGGER.warning("Kumo %s could not be set up", name)
+            continue
+        kumo_station = KumoStationOutdoorTemperature(kumo_api, unit)
+        await hass.async_add_executor_job(kumo_station.update)
+        devices.append(kumo_station)
+        _LOGGER.debug("Kumo adding entity: %s", name)
+    if devices:
+        async_add_entities(devices)
+
+
+class KumoStationOutdoorTemperature(SensorEntity):
+    """Representation of a Kumo Station Outdoor Temperature Sensor."""
+
+    def __init__(self, kumo_api, unit):
+        """Initialize the kumo station."""
+
+        self._name = kumo_api.get_name() + " Outdoor Temperature"
+        self._identifier = unit
+        self._outdoor_temperature = None
+        self._rssi = None
+        self._pykumo = kumo_api
+        self._unavailable_count = 0
+        self._available = False
+
+    def update(self):
+        """Call from HA to trigger a refresh of cached state."""
+        success = self._pykumo.update_status()
+        self._update_availability(success)
+        self._outdoor_temperature = self._pykumo.get_outdoor_temperature()
+
+    def _update_availability(self, success):
+        if success:
+            self._available = True
+            self._unavailable_count = 0
+        else:
+            self._unavailable_count += 1
+            if self._unavailable_count >= MAX_AVAILABILITY_TRIES:
+                self._available = False
+
+    @property
+    def available(self):
+        """Return whether Home Assistant is able to read the state and control the underlying device."""
+        return self._available
+
+    @property
+    def name(self):
+        """Return the name of the thermostat, if any."""
+        return self._name
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return the unit of measurement which this thermostat uses."""
+        return TEMP_CELSIUS
+
+    @property
+    def native_value(self):
+        """Return the high dual setpoint temperature."""
+        return self._outdoor_temperature
+
+    @property
+    def device_class(self):
+        return DEVICE_CLASS_TEMPERATURE
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def unique_id(self):
+        """Return unique id"""
+        return self._identifier
+
+    @property
+    def device_info(self):
+        """Return device information for this Kumo Station"""
+        return {
+            "identifiers": {(DOMAIN, self._identifier)},
+            "name": self.name,
+            "manufacturer": "Mistubishi",
+        }

--- a/custom_components/kumo/strings.json
+++ b/custom_components/kumo/strings.json
@@ -1,50 +1,51 @@
 {
   "title": "Kumo",
   "config": {
-    "step": {
-      "user": {
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "prefer_cache": "Prefer Cached JSON",
-        }
-      }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
-    "request_ips": {"title": "IP Assignment", "description": "Kumo failed to return an IP for the following units:"}
-  }
-},
-"options": {
-  "step": {
-    "init": {
-      "title": "Configure Kumo",
-      "description": "What would you like to edit?",
-      "data": {
-        "edit_select": "Edit"
-      }
+    "error": {
+      "cannot_connect": "Cannot Connect to KumoCloud, check internet connection",
+      "invalid_auth": "Invalid Credentials, Wrong user or password",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "timeout_settings": {
-      "data": {
-        "connect_timeout": "Connect Timeout",
-        "response_timeout": "Response Timeout",
+    "step": {
+      "user": {
+        "data": {
+          "username": "KumoCloud Username (Email Address)",
+          "password": "KumoCloud Password",
+          "prefer_cache": "Prefer Local Cache"
+        }
+      },
+      "request_ips": {
+        "title": "IP Assignment",
+        "description": "Kumo failed to return an IP address. For the following units, please replace the text with their local IP addresses"
       }
-    },
-    "unit_select": {
-      "title": "You can set the local IP of your unit in the cache file here",
-      "description": "You must reload the integration after setting IP addresses",
-      "data": {
-        "unit_label": "Unit Name",
-        "ip_address": "IP Address"
-
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure Kumo",
+        "description": "What would you like to edit?",
+        "data": {
+          "edit_select": "Edit"
+        }
+      },
+      "timeout_settings": {
+        "data": {
+          "connect_timeout": "Connection Timout",
+          "response_timeout": "Response Timeout"
+        }
+      },
+      "unit_select": {
+        "title": "You can set the local IP of your unit in the cache file here",
+        "description": "You must reload the integration after setting IP addresses",
+        "data": {
+          "unit_label": "Unit Label",
+          "ip_address": "IP Address"
+        }
       }
     }
   }
-}
 }

--- a/custom_components/kumo/translations/en.json
+++ b/custom_components/kumo/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "title": "Kumo",
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
@@ -46,6 +47,5 @@
         }
       }
     }
-  },
-  "title": "Kumo"
+  }
 }


### PR DESCRIPTION
Rough draft to pair with https://github.com/dlarrick/pykumo/pull/17

This PR adds support for outdoor temperature from the Kumo Station if one is equipped in your system.

Concerns I still need to address:
[] Is the way we are starting up 2 domains now ok? Need to read up on platforms vs domains vs integrations
[] Can we abstract the update command to be once for the station, and update X sensors, in case we add more in the future