### PR TITLE
Enable turn-on/turn-off capabilities

### DIFF
--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "codeowners": [ "@dlarrick" ],
     "requirements": ["pykumo==0.3.5"],
-    "version": "0.3.6",
+    "version": "0.3.7",
     "homeassistant": "2021.12.0"
 }


### PR DESCRIPTION
Enable the ability to toggle a unit on/off based on some trigger.  Cases where multiple units are part of an automation, it is important to retain the previous HVAC mode when turning back on given "climate" doesn't expose this as a property.  A better solution would be changes to climate to retain the previous HVAC mode state and enable decisions based on that data.

Changes:
* Add turn-on/turn-off methods
* Retain previous hvac-mode on state
* Move all setter methods to async