### PR TITLE
add /#/ to login url to match web version

### DIFF
--- a/custom_components/kumo/kumo_cloud_setup.py
+++ b/custom_components/kumo/kumo_cloud_setup.py
@@ -13,7 +13,7 @@ def main():
     username = input("KumoCloud username:")
     password = getpass.getpass(prompt="KumoCloud password:")
 
-    url = "https://app.kumocloud.com/login"
+    url = "https://app.kumocloud.com/#/login"
     headers = {
         "Accept": "application/json, text/plain, */*",
         "Accept-Encoding": "gzip, deflate, br",


### PR DESCRIPTION
It appears the web login for Kumo Cloud has changed: https://app.kumocloud.com/#/login

Update the login URL in kumo_cloud_setup.py from https://app.kumocloud.com/login to https://app.kumocloud.com/#/login

Fixes #109 for me

Successfully can login but the integration doesn't properly pull the IP automatically and that must be entered manually.