### PR TITLE
Add ClimateEntityFeature.TURN_OFF for Google Assistant calls

### DIFF
--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -155,7 +155,9 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
         self._swing_modes = self._pykumo.get_vane_directions()
         self._hvac_modes = [HVACMode.OFF, HVACMode.COOL]
         self._supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+            ClimateEntityFeature.TARGET_TEMPERATURE |
+            ClimateEntityFeature.FAN_MODE |
+            ClimateEntityFeature.TURN_OFF
         )
         if self._pykumo.has_dry_mode():
             self._hvac_modes.append(HVACMode.DRY)


### PR DESCRIPTION
Google Assistant expects to call the turn_off service which does not exist unless specifically enabled as a ClimateEntityFeature.TURN_OFF feature.

Previously calls to turn off my Kumo devices would fail silently from Google and an error message in Home Assistant regarding an unsupported service.

I have tested this change to fix my issue.