### PR TITLE
Run `pre-commit` in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+---
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This is a followup to #134 to run the `pre-commit` linters in CI and report errors. See docs at https://github.com/pre-commit/action?tab=readme-ov-file#using-this-action