### PR TITLE
Use `Platform.CLIMATE` / `Platform.SENSOR` instead of 'domain' constants

### DIFF
--- a/custom_components/kumo/const.py
+++ b/custom_components/kumo/const.py
@@ -3,8 +3,7 @@
 from datetime import timedelta
 from typing import Final
 
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import Platform
 
 DEFAULT_NAME = "Kumo"
 DOMAIN = "kumo"
@@ -16,10 +15,6 @@ CONF_CONNECT_TIMEOUT = "connect_timeout"
 CONF_RESPONSE_TIMEOUT = "response_timeout"
 MAX_AVAILABILITY_TRIES = 3 # How many times we will attempt to update from a kumo before marking it unavailable
 
-PLATFORMS: Final = [CLIMATE_DOMAIN, SENSOR_DOMAIN]
-
-# This is the new way of important platforms, but isn't public yet
-# from homeassistant.const import Platform
-# PLATFORMS: Final = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS: Final = [Platform.CLIMATE, Platform.SENSOR]
 
 SCAN_INTERVAL = timedelta(seconds=60)


### PR DESCRIPTION
This is a minor cleanup with no change in functionality but it avoids using "domain" strings in place of "platform" strings