### PR TITLE
Add basic get/set schedule actions

### DIFF
--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -53,20 +53,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-SCHEDULE_SETTINGS_SCHEMA = vol.Schema({
-    "mode": cv.string,
-    "vaneDir": cv.string,
-    "fanSpeed": cv.string,
-}, extra=vol.ALLOW_EXTRA)
-
-SCHEDULE_EVENT_SCHEMA = {
-    "active": cv.boolean,
-    "inUse": cv.boolean,
-    "day": cv.string,
-    "time": cv.string,
-    "settings": SCHEDULE_SETTINGS_SCHEMA,
-}
-
 KUMO_STATE_AUTO = "auto"
 KUMO_STATE_AUTO_COOL = "autoCool"
 KUMO_STATE_AUTO_HEAT = "autoHeat"

--- a/custom_components/kumo/services.yaml
+++ b/custom_components/kumo/services.yaml
@@ -1,0 +1,16 @@
+get_hvac_schedule:
+  description: Get HVAC schedule
+  target:
+    entity:
+      domain: "climate"
+      integration: "kumo"
+
+set_hvac_schedule:
+  description: Set HVAC schedule
+  target:
+    entity:
+      domain: "climate"
+      integration: "kumo"
+  fields:
+    schedule:
+      required: true

--- a/custom_components/kumo/translations/en.json
+++ b/custom_components/kumo/translations/en.json
@@ -47,5 +47,21 @@
         }
       }
     }
+  },
+  "services": {
+    "get_hvac_schedule": {
+      "name": "Get HVAC schedule (advanced)",
+      "description": "Fetch the HVAC schedule for this unit. This is intended for advanced usage in scripts only."
+    },
+    "set_hvac_schedule": {
+      "name": "Set HVAC schedule (advanced)",
+      "description": "Set the HVAC schedule for this unit. This is intended for advanced usage in scripts only.",
+      "fields": {
+        "schedule": {
+          "name": "Schedule",
+          "description": "Schedule (in a JSON structure) to set."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This is primarily intended for demonstration/discussion purposes. Also my first Home Assistant component PR, so feedback highly welcomed! Related issue: https://github.com/dlarrick/pykumo/issues/51

Is this the API we want? Get/set are pretty low level (which might be fine). With a little work, we could also make it easy to enable/disable a range of schedule slots. With more work, we could make it so that Home Assistant could set all the fields in a single slot.

Note that this doesn't work on its own -- it needs to be used in conjunction an updated version of PyKumo which includes https://github.com/dlarrick/pykumo/pull/53.

Before finalizing:
- [ ] Update PyKumo version in `manifest.json` to v0.3.11
- [ ] Tighten validation?