### PR TITLE
Implement `climate.turn_on`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,16 +148,18 @@ Use the standard `climate` service calls to control or automate each unit. Avail
 - `climate.set_fan_mode`
 - `climate.set_hvac_mode`
 - `climate.set_swing_mode`
+- `climate.turn_on`
 - `climate.turn_off`
 
 Specific support and behavior can vary, depending on the capabilities of your indoor unit.
+When `climate.turn_on` is called, the integration restores the last active HVAC mode for that unit using the `Last HVAC Mode` sensor.
 
 ## Home Assistant Sensors
 
 Useful information from indoor units is provided as attributes on the associated `climate` entity. This data can be turned into sensors in one of two ways: sensors provided by the integration, or template sensors from the main entity's attributes.
 
 ### Sensors
-By default a sensor for current temperature is enabled. It's possible to enable sensors for a few other values, if available:
+By default sensors for current temperature and last HVAC mode are enabled. It's possible to enable sensors for a few other values, if available:
 - WiFi RSSI signal strength
 - Current Humidity (provided by a linked PAC-USWHS003 or MHK2 device)
 - PAC sensor battery level
@@ -221,7 +223,6 @@ For bugs or feature improvements, feel free to create a GitHub issue or pull req
 - Debugging for different types of indoor units.
 - Explore if other local APIs are available to provide additional useful information (whether a unit is calling, etc.).
 - Code cleanup. Code reviews welcome!
-- Implement `climate.turn_on` action (service).
 - Possible enhancement: allow setup and control of schedules and operating modes on the indoor unit itself.
 - Possibly work toward inclusion as an official Home Assistant integration.
 

--- a/custom_components/kumo/last_hvac_mode.py
+++ b/custom_components/kumo/last_hvac_mode.py
@@ -1,0 +1,75 @@
+"""Shared storage for last active HVAC mode."""
+from __future__ import annotations
+
+from homeassistant.components.climate.const import HVACMode
+
+from .const import DOMAIN
+
+_LAST_HVAC_MODE_KEY = "last_hvac_mode"
+_LAST_HVAC_MODE_LISTENERS = "last_hvac_mode_listeners"
+
+
+def _get_store(hass):
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    return domain_data.setdefault(_LAST_HVAC_MODE_KEY, {})
+
+
+def _get_listeners(hass):
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    return domain_data.setdefault(_LAST_HVAC_MODE_LISTENERS, {})
+
+
+def get_last_hvac_mode_value(hass, identifier):
+    """Return the cached last HVAC mode string, if any."""
+    if not hass or not identifier:
+        return None
+    return _get_store(hass).get(identifier)
+
+
+def set_last_hvac_mode_value(hass, identifier, value):
+    """Store the cached last HVAC mode string."""
+    if not hass or not identifier or not value:
+        return
+    store = _get_store(hass)
+    if store.get(identifier) == value:
+        return
+    store[identifier] = value
+    _notify_listeners(hass, identifier, value)
+
+
+def get_last_hvac_mode(hass, identifier, hvac_modes):
+    """Return the cached last HVAC mode as an HVACMode, if any."""
+    value = get_last_hvac_mode_value(hass, identifier)
+    if value:
+        for mode in hvac_modes:
+            if mode != HVACMode.OFF and mode.value == value:
+                return mode
+    return None
+
+
+def register_last_hvac_mode_listener(hass, identifier, callback):
+    """Register a callback for last HVAC mode updates."""
+    if not hass or not identifier:
+        return lambda: None
+    listeners = _get_listeners(hass)
+    callbacks = listeners.setdefault(identifier, set())
+    callbacks.add(callback)
+
+    def _unsubscribe():
+        callbacks.discard(callback)
+        if not callbacks:
+            listeners.pop(identifier, None)
+
+    return _unsubscribe
+
+
+def _notify_listeners(hass, identifier, value):
+    callbacks = _get_listeners(hass).get(identifier)
+    if not callbacks:
+        return
+
+    def _run():
+        for callback in list(callbacks):
+            callback(value)
+
+    hass.loop.call_soon_threadsafe(_run)


### PR DESCRIPTION
Resolves #181

This implements `turn_on` and adds a "Last HVAC Mode" sensor with restore support and a lightweight in-memory store shared with the climate entity. The climate entity now persists the last active (non‑off) HVAC mode whenever the device mode updates, and `turn_on` uses that cached value (falling back to the first supported non‑off mode if none is known).