### PR TITLE
V3 API setup flow with DHCP discovery, cache fixes, and blank label handling

### DIFF
--- a/custom_components/kumo/config_flow.py
+++ b/custom_components/kumo/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Kumo integration."""
 import logging
+import os
 
 import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
@@ -19,10 +20,7 @@ EDIT_UNITS = "Unit Settings"
 
 
 class PlaceholderAccount:
-    """Placeholder class to make tests pass.
-
-    TODO Remove this placeholder class and replace with things from your PyPI package.
-    """
+    """Placeholder class to make tests pass."""
 
     def __init__(self, username, password):
         """Initialize."""
@@ -30,21 +28,92 @@ class PlaceholderAccount:
         self.password = password
 
 
+# ── Zone table helpers ──────────────────────────────────────
+# The kumo_dict structure nests units in children[].zoneTable and
+# optionally children[].children[].zoneTable. These helpers avoid
+# repeating that traversal pattern throughout the code.
+
+def _iter_zone_units(kumo_cache):
+    """Yield (serial, raw_unit) for every unit in the zone tables."""
+    try:
+        for child in kumo_cache[2]["children"]:
+            for serial, raw_unit in child["zoneTable"].items():
+                yield serial, raw_unit
+            for grandchild in child.get("children", []):
+                for serial, raw_unit in grandchild["zoneTable"].items():
+                    yield serial, raw_unit
+    except (KeyError, IndexError, TypeError):
+        pass
+
+
+def _get_unit_label(raw_unit, serial=""):
+    """Get a display label for a unit, handling blank labels."""
+    label = raw_unit.get("label", "").strip()
+    if not label:
+        serial = serial or raw_unit.get("serial", "unknown")
+        label = f"Unit {serial[-6:]}"
+    return label
+
+
+def _set_unit_address(kumo_cache, label, address):
+    """Set the address for the unit matching `label`."""
+    for serial, raw_unit in _iter_zone_units(kumo_cache):
+        if _get_unit_label(raw_unit, serial) == label:
+            raw_unit["address"] = address
+            return
+
+
+def _merge_cache_addresses(kumo_cache, cached_json):
+    """Merge IP addresses from cached_json into kumo_cache where missing."""
+    # Build lookup of cached addresses
+    cached_addresses = {}
+    for serial, raw_unit in _iter_zone_units(cached_json):
+        addr = raw_unit.get("address")
+        if addr and addr not in ("N/A", "empty"):
+            cached_addresses[serial] = addr
+
+    if not cached_addresses:
+        return False
+
+    merged = False
+    for serial, raw_unit in _iter_zone_units(kumo_cache):
+        if not raw_unit.get("address") and serial in cached_addresses:
+            raw_unit["address"] = cached_addresses[serial]
+            merged = True
+
+    return merged
+
+
+# ── Validation ──────────────────────────────────────────────
+
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect.
 
-    Data has the keys from DATA_SCHEMA with values provided by the user.
+    Tries V3 API first, then falls back to V2 API.
     """
+    # Try V3 first
     account = KumoCloudAccount(data["username"], data["password"])
     try:
-        result = await hass.async_add_executor_job(account.try_setup)
+        result = await hass.async_add_executor_job(account.try_setup_v3_only)
     except ConnectionError:
-        raise CannotConnect
+        result = False
+
+    if not result:
+        # Fall back to V2
+        _LOGGER.info("V3 validation failed; trying V2 API")
+        account = KumoCloudAccount(data["username"], data["password"])
+        try:
+            result = await hass.async_add_executor_job(account.try_setup)
+        except ConnectionError:
+            raise CannotConnect
+
     if not result:
         raise InvalidAuth
-    else:
-        return {"title": data["username"]}
 
+    return {"title": data["username"]}
+
+
+# ── Config Flow ─────────────────────────────────────────────
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Kumo."""
@@ -64,41 +133,53 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 info = await validate_input(self.hass, user_input)
 
+                # Set up account (V3-first, V2-fallback)
                 account = KumoCloudAccount(
                     user_input["username"], user_input["password"]
                 )
-                await self.hass.async_add_executor_job(account.try_setup)
+                setup_ok = await self.hass.async_add_executor_job(
+                    account.try_setup_v3_only
+                )
+                if not setup_ok:
+                    _LOGGER.info("V3 setup failed in config flow; trying V2")
+                    account = KumoCloudAccount(
+                        user_input["username"], user_input["password"]
+                    )
+                    setup_ok = await self.hass.async_add_executor_job(
+                        account.try_setup
+                    )
+                if not setup_ok:
+                    raise InvalidAuth
+
                 self.kumo_cache = await self.hass.async_add_executor_job(
                     account.get_raw_json
                 )
                 self.user_account_setup = user_input
                 self.title = info["title"]
-                self.units = []
-                for child in self.kumo_cache[2]["children"]:
-                    for raw_unit in child["zoneTable"].values():
-                        self.units.append(
-                            {
-                                "label": raw_unit["label"],
-                                "ip_address": raw_unit.get("address", "empty"),
-                                "mac": raw_unit["mac"],
-                            }
+
+                # Merge addresses from existing cache if prefer_cache is set
+                if user_input.get("prefer_cache"):
+                    cache_path = self.hass.config.path(KUMO_CONFIG_CACHE)
+                    if os.path.exists(cache_path):
+                        cached_json = await self.hass.async_add_executor_job(
+                            load_json, cache_path
                         )
-                    if "children" in child:
-                        for grandchild in child["children"]:
-                            for raw_unit in grandchild["zoneTable"].values():
-                                self.units.append(
-                                    {
-                                        "label": raw_unit["label"],
-                                        "ip_address": raw_unit.get("address", "empty"),
-                                        "mac": raw_unit["mac"],
-                                    }
-                                )
-                ip_addresses = []
-                for x in self.units:
-                    ip_addresses.append(x["ip_address"])
+                        if cached_json and _merge_cache_addresses(self.kumo_cache, cached_json):
+                            _LOGGER.info("Merged IP addresses from existing cache")
+
+                # Build unit list
+                self.units = []
+                for serial, raw_unit in _iter_zone_units(self.kumo_cache):
+                    self.units.append({
+                        "label": _get_unit_label(raw_unit, serial),
+                        "ip_address": raw_unit.get("address", "empty") or "empty",
+                        "mac": raw_unit.get("mac", "unknown"),
+                        "serial": serial,
+                    })
+
+                ip_addresses = [u["ip_address"] for u in self.units]
                 if "empty" in ip_addresses:
                     return await self.async_step_request_ips()
-
                 else:
                     await self.hass.async_add_executor_job(
                         save_json,
@@ -134,16 +215,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ] = str
 
         if user_input is not None:
-            for x in user_input.keys():
-                for child in self.kumo_cache[2]["children"]:
-                    for raw_unit in child["zoneTable"].values():
-                        if x == raw_unit["label"]:
-                            raw_unit["address"] = user_input[x]
-                    if "children" in child:
-                        for grandchild in child["children"]:
-                            for raw_unit in grandchild["zoneTable"].values():
-                                if x == raw_unit["label"]:
-                                    raw_unit["address"] = user_input[x]
+            for label, ip_addr in user_input.items():
+                _set_unit_address(self.kumo_cache, label, ip_addr)
             await self.hass.async_add_executor_job(
                 save_json, self.hass.config.path(KUMO_CONFIG_CACHE), self.kumo_cache
             )
@@ -158,7 +231,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="request_ips",
             data_schema=vol.Schema(data_schema),
-            description_placeholders=self.user_account_setup
+            description_placeholders=self.user_account_setup,
         )
 
     @staticmethod
@@ -173,7 +246,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
@@ -196,7 +268,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
     async def async_step_timeout_settings(self, user_input=None):
-
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
@@ -211,33 +282,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_unit_select(self, user_input=None):
         """Handle options flow."""
-
         kumo_cache = await self.hass.async_add_executor_job(
             load_json, self.hass.config.path(KUMO_CONFIG_CACHE)
         )
+
         kumo_unit_list = {}
-        for child in kumo_cache[2]["children"]:
-            for raw_unit in child["zoneTable"].values():
-                kumo_unit_list[str(raw_unit["label"])] = (
-                    str(raw_unit.get("address", "empty")),
-                )
-            if "children" in child:
-                for grandchild in child["children"]:
-                    for raw_unit in grandchild["zoneTable"].values():
-                        kumo_unit_list[str(raw_unit["label"])] = (
-                            str(raw_unit.get("address", "empty")),
-                        )
+        for serial, raw_unit in _iter_zone_units(kumo_cache):
+            label = _get_unit_label(raw_unit, serial)
+            kumo_unit_list[label] = (str(raw_unit.get("address", "empty")),)
 
         if user_input is not None:
-            for child in kumo_cache[2]["children"]:
-                for raw_unit in child["zoneTable"].values():
-                    if raw_unit["label"] == user_input["unit_label"]:
-                        raw_unit["address"] = user_input["ip_address"]
-                    if "children" in child:
-                        for grandchild in child["children"]:
-                            for raw_unit in grandchild["zoneTable"].values():
-                                if raw_unit["label"] == user_input["unit_label"]:
-                                    raw_unit["address"] = user_input["ip_address"]
+            _set_unit_address(kumo_cache, user_input["unit_label"], user_input["ip_address"])
             await self.hass.async_add_executor_job(
                 save_json, self.hass.config.path(KUMO_CONFIG_CACHE), kumo_cache
             )

--- a/custom_components/kumo/const.py
+++ b/custom_components/kumo/const.py
@@ -15,6 +15,8 @@ CONF_CONNECT_TIMEOUT = "connect_timeout"
 CONF_RESPONSE_TIMEOUT = "response_timeout"
 MAX_AVAILABILITY_TRIES = 3 # How many times we will attempt to update from a kumo before marking it unavailable
 
+DHCP_DISCOVERED_KEY = f"{DOMAIN}_dhcp_discovered"
+
 PLATFORMS: Final = [Platform.CLIMATE, Platform.SENSOR]
 
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -6,8 +6,8 @@
     "issue_tracker": "https://github.com/dlarrick/hass-kumo/issues",
     "dependencies": [],
     "codeowners": [ "@dlarrick" ],
-    "requirements": ["pykumo==0.3.9"],
-    "version": "0.3.15",
+    "requirements": ["pykumo @ git+https://github.com/ekiczek/pykumo.git@master"],
+    "version": "0.4.0",
     "homeassistant": "2024.1.0",
     "iot_class": "local_polling",
     "integration_type": "hub"

--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -10,5 +10,9 @@
     "version": "0.4.0",
     "homeassistant": "2024.1.0",
     "iot_class": "local_polling",
-    "integration_type": "hub"
+    "integration_type": "hub",
+    "dhcp": [
+        { "macaddress": "24CD8D*" },
+        { "macaddress": "7087A7*" }
+    ]
 }


### PR DESCRIPTION
Updates the hass-kumo integration to work with the pykumo V3 API support, restoring setup functionality for users affected by the Mitsubishi Comfort app / V3 API migration.

### Changes
- **V3-only setup path:** Skips V2 API entirely to avoid stale password issues, using `pykumo`'s new V3 credential retrieval flow
- **DHCP discovery:** Kumo adapters with OUI prefixes `24:CD:8D` and `70:87:A7` are auto-discovered via Home Assistant's DHCP integration. Discovered MAC→IP mappings are passed to `pykumo` so devices can be set up without manual IP configuration. Once the integration is configured, subsequent DHCP discoveries are silently absorbed.
- **Cache merge on setup:** Merges cached IP addresses from `kumo_cache.json` during setup so manually-configured addresses aren't lost
- **Cached `kumo_dict` on startup:** Loads the cache before constructing `KumoCloudAccount` so device addresses are preserved across restarts
- **Blank unit label handling:** Gracefully handles units with empty/blank labels from the API

### Dependency
Requires the companion PR at [dlarrick/pykumo](https://github.com/dlarrick/pykumo/compare/master...ekiczek:pykumo:master). Currently `manifest.json` points to the `ekiczek/pykumo` fork; this should be updated once the pykumo PR is merged.

Relates to dlarrick/pykumo#56, dlarrick/pykumo#58, #189