### PR TITLE
Add Mitsubishi-specific F/C temperature conversion

### DIFF
--- a/custom_components/kumo/sensor.py
+++ b/custom_components/kumo/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from .const import DOMAIN, KUMO_DATA_COORDINATORS
 from .coordinator import KumoDataUpdateCoordinator
 from .entity import CoordinatedKumoEntity
+from .temperature import c_to_f
 
 try:
     from homeassistant.components.sensor import SensorEntity
@@ -111,6 +112,11 @@ class KumoCurrentTemperature(CoordinatedKumoEntity, SensorEntity):
         self._name = self._pykumo.get_name() + " Current Temperature"
 
     @property
+    def _use_fahrenheit(self):
+        """Return True if the user's HA config is set to Fahrenheit."""
+        return self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT
+
+    @property
     def unique_id(self):
         """Return unique id"""
         return f"{self._identifier}-current-temperature"
@@ -118,12 +124,17 @@ class KumoCurrentTemperature(CoordinatedKumoEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement which this thermostat uses."""
+        if self._use_fahrenheit:
+            return UnitOfTemperature.FAHRENHEIT
         return UnitOfTemperature.CELSIUS
 
     @property
     def native_value(self):
         """Return the current temperature."""
-        return self._pykumo.get_current_temperature()
+        temp = self._pykumo.get_current_temperature()
+        if self._use_fahrenheit:
+            temp = c_to_f(temp)
+        return temp
 
     @property
     def device_class(self):
@@ -213,6 +224,11 @@ class KumoStationOutdoorTemperature(CoordinatedKumoEntity, SensorEntity):
         self._name = self._pykumo.get_name() + " Outdoor Temperature"
 
     @property
+    def _use_fahrenheit(self):
+        """Return True if the user's HA config is set to Fahrenheit."""
+        return self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT
+
+    @property
     def unique_id(self):
         """Return unique id"""
         return f"{self._identifier}-outdoor-temperature"
@@ -220,12 +236,17 @@ class KumoStationOutdoorTemperature(CoordinatedKumoEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement which this thermostat uses."""
+        if self._use_fahrenheit:
+            return UnitOfTemperature.FAHRENHEIT
         return UnitOfTemperature.CELSIUS
 
     @property
     def native_value(self):
         """Return the unit's reported outdoor temperature."""
-        return self._pykumo.get_outdoor_temperature()
+        temp = self._pykumo.get_outdoor_temperature()
+        if self._use_fahrenheit:
+            temp = c_to_f(temp)
+        return temp
 
     @property
     def device_class(self):

--- a/custom_components/kumo/temperature.py
+++ b/custom_components/kumo/temperature.py
@@ -1,0 +1,48 @@
+"""Mitsubishi-specific temperature conversion utilities.
+
+Mitsubishi systems use 0.5C steps internally, but their F-to-C mapping
+diverges from standard math at several points (64-66F, 69-72F). Using
+these lookup tables ensures setpoints match the Comfort app and physical
+thermostat exactly.
+"""
+
+import math
+
+# Mitsubishi's proprietary Fahrenheit-to-Celsius setpoint mapping (61-80F)
+F_TO_C: dict[int, float] = {
+    61: 16.0, 62: 16.5, 63: 17.0, 64: 17.5, 65: 18.0, 66: 18.5,
+    67: 19.5, 68: 20.0, 69: 21.0, 70: 21.5, 71: 22.0, 72: 22.5,
+    73: 23.0, 74: 23.5, 75: 24.0, 76: 24.5, 77: 25.0, 78: 25.5,
+    79: 26.0, 80: 26.5,
+}
+
+# Reverse mapping: Celsius to Fahrenheit for display
+C_TO_F: dict[float, int] = {
+    16.0: 61, 16.5: 62, 17.0: 63, 17.5: 64, 18.0: 65, 18.5: 66,
+    19.0: 67, 19.5: 67, 20.0: 68, 20.5: 69,
+    21.0: 69, 21.5: 70, 22.0: 71, 22.5: 72,
+    23.0: 73, 23.5: 74, 24.0: 75, 24.5: 76, 25.0: 77, 25.5: 78,
+    26.0: 79, 26.5: 80,
+}
+
+
+def c_to_f(celsius: float) -> float:
+    """Convert Celsius to Fahrenheit using Mitsubishi lookup, with standard fallback."""
+    if celsius is None:
+        return None
+    result = C_TO_F.get(celsius)
+    if result is not None:
+        return result
+    return round(celsius * 9 / 5 + 32)
+
+
+def f_to_c(fahrenheit: float) -> float:
+    """Convert Fahrenheit to Celsius using Mitsubishi lookup, with fallback to nearest 0.5C."""
+    if fahrenheit is None:
+        return None
+    result = F_TO_C.get(int(fahrenheit))
+    if result is not None:
+        return result
+    # Fallback: standard conversion rounded to nearest 0.5C
+    raw = (fahrenheit - 32) * 5 / 9
+    return math.floor(raw * 2 + 0.5) / 2


### PR DESCRIPTION
## Summary

- Adds Mitsubishi-specific lookup tables for Fahrenheit↔Celsius conversion that match the Comfort app and physical thermostat exactly, fixing up to 1°F drift for Fahrenheit users
- Detects the user's configured HA unit system at runtime so Celsius users are completely unaffected (values pass through unchanged)
- Adds `target_temperature_step` (1°F or 0.5°C) for correct step sizing in the UI

### Background

Mitsubishi systems use 0.5°C steps internally, but their F-to-C mapping diverges from standard math at several points (64-66°F, 69-72°F). This is the same fix applied to `kumo_cloud` in [jjustinwilson/comfort_HA#23](https://github.com/jjustinwilson/comfort_HA/pull/23), adapted for hass-kumo with an improvement: instead of hardcoding Fahrenheit, we check `hass.config.units.temperature_unit` so both F and C users get correct values.

### Files changed

- **`temperature.py`** (new) — shared lookup tables (`F_TO_C`, `C_TO_F`) and conversion helpers (`c_to_f`, `f_to_c`)
- **`climate.py`** — climate entity conditionally converts temperatures based on user unit system
- **`sensor.py`** — temperature sensors (`KumoCurrentTemperature`, `KumoStationOutdoorTemperature`) conditionally convert

## Test plan

- [ ] Deploy to HA instance with Imperial (°F) unit system
- [ ] Verify climate entity current temperature matches Comfort app
- [ ] Set each target temp 61-80°F and confirm it matches thermostat/Comfort app
- [ ] Verify both temperature sensors report correctly in °F
- [ ] Test all HVAC modes (heat, cool, heat_cool) with setpoint changes
- [ ] Switch HA to Metric (°C) and verify values pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)