### PR TITLE
Fix auto (heat_cool) mode suppressed by autoModePrevention

### DIFF
--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -195,6 +195,17 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
             if not self.available:
                 # Get out early if it's failing
                 break
+        # The adapter's autoModePrevention flag can incorrectly suppress
+        # auto mode even when the unit supports it. Check the unit profile's
+        # auto setpoints as a reliable indicator of actual capability.
+        if HVACMode.HEAT_COOL not in self._hvac_modes:
+            profile = getattr(self._pykumo, '_profile', {})
+            max_sp = profile.get('maximumSetPoints', {})
+            if 'auto' in max_sp:
+                self._hvac_modes.append(HVACMode.HEAT_COOL)
+                self._supported_features |= (
+                    ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+                )
 
     def _update_property(self, prop):
         """Call to refresh the value of a property -- may block on I/O."""


### PR DESCRIPTION
## Summary

- The adapter's `autoModePrevention` flag causes pykumo to set `hasModeAuto=False`, which prevents the `heat_cool` HVAC mode from being exposed in Home Assistant
- However, this flag does not mean the unit lacks auto mode capability — the Mitsubishi Comfort app and cloud-based Mitsubishi Comfort integration both allow auto mode with the same adapter configuration
- The unit profile itself confirms auto mode support by including `auto` setpoints in `maximumSetPoints`/`minimumSetPoints` (e.g. `{'cool': 30, 'heat': 28, 'auto': 28}`)
- This change checks for those setpoints as a reliable indicator of actual capability, adding `heat_cool` mode on each update cycle if the unit supports it but the mode was suppressed during init

## Context

When `autoModePrevention` is `True` on the adapter, pykumo inverts it to `hasModeAuto=False` in `update_status()`. The climate entity checks `has_auto_mode()` once during `__init__` and never rechecks, so `heat_cool` is permanently hidden.

The fix uses the unit profile's own auto setpoints as ground truth. If `maximumSetPoints` contains an `auto` key, the unit supports auto mode regardless of the adapter-level flag. This aligns with the behavior of the official Mitsubishi Comfort app and cloud integration.

## Test plan

- [x] Verified on a Mitsubishi mini-split with `autoModePrevention=True` on the adapter
- [x] `heat_cool` mode appears in HA after the fix
- [x] Unit successfully operates in auto mode via HA
- [x] No impact when `autoModePrevention` is `False` (mode was already exposed)
- [ ] Confirm no regression on units that genuinely lack auto mode (no `auto` key in `maximumSetPoints`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)