### PR TITLE
Add DHCP MAC prefix 38:8D:3D (WNC Corporation)

### DIFF
--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -13,6 +13,7 @@
     "integration_type": "hub",
     "dhcp": [
         { "macaddress": "24CD8D*" },
+        { "macaddress": "388D3D*" },
         { "macaddress": "7087A7*" }
     ]
 }


### PR DESCRIPTION
Some Kumo WiFi adapters use the `38:8D:3D` OUI (WNC Corporation), alongside the existing Murata prefixes (`24:CD:8D`, `70:87:A7`). Without this entry, HA's DHCP integration can't detect these adapters, so `candidate_ips` is never populated for `probe_candidate_ips()`.

I confirmed the prefix on three PAC-USWHS002-WF-2 adapters.