### PR TITLE
Remove redundant should_poll override on CoordinatorEntity

### DIFF
--- a/custom_components/kumo/entity.py
+++ b/custom_components/kumo/entity.py
@@ -34,11 +34,6 @@ class CoordinatedKumoEntity(CoordinatorEntity):
         )
 
     @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
-
-    @property
     def available(self):
         """Return whether Home Assistant is able to read the state and control the underlying device."""
         return self._coordinator.get_available()


### PR DESCRIPTION
## Summary

`CoordinatedKumoEntity` overrides `should_poll` to return `True`. Because it extends `CoordinatorEntity`, this causes HA's entity-level polling loop to fire every ~30 seconds **in addition to** the coordinator's own polling cycle — double-polling each device with no benefit.

`CoordinatorEntity` already returns `False` for `should_poll` by default (the coordinator is the intended polling mechanism). This removes the override entirely.

## Test plan

- [ ] Reload the Kumo integration and confirm all entities update normally
- [ ] Confirm in logs that coordinator polls fire on the expected interval and no redundant entity-level polls appear