### PR TITLE
Add async post-command coordinator refresh with configurable delay

### DIFF
--- a/custom_components/kumo/__init__.py
+++ b/custom_components/kumo/__init__.py
@@ -102,7 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         pykumos = await hass.async_add_executor_job(account.make_pykumos, timeouts, True)
         for device in pykumos.values():
             if device.get_serial() not in coordinators:
-                coordinators[device.get_serial()] = KumoDataUpdateCoordinator(hass, device)
+                coordinators[device.get_serial()] = KumoDataUpdateCoordinator(hass, device, config_entry=entry)
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         return True

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.components.climate import PLATFORM_SCHEMA
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .const import CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL, DOMAIN
 from .coordinator import KumoDataUpdateCoordinator
 from .entity import CoordinatedKumoEntity
 from .temperature import c_to_f, f_to_c
@@ -458,7 +458,20 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
             "manufacturer": "Mitsubishi",
         }
 
-    def set_temperature(self, **kwargs):
+    async def _delayed_refresh(self):
+        """Wait briefly for the unit to apply a command, then refresh coordinator state."""
+        import asyncio
+        delay = DEFAULT_REFRESH_INTERVAL
+        if self.coordinator._config_entry is not None:
+            delay = float(
+                self.coordinator._config_entry.options.get(
+                    CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
+                )
+            )
+        await asyncio.sleep(delay)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         _LOGGER.debug(
             "Kumo %s set temp: %s, current mode %s",
@@ -508,7 +521,7 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
             return
 
         if current_mode != target_mode:
-            self.set_hvac_mode(target_mode)
+            await self.async_set_hvac_mode(target_mode)
 
         if self._use_fahrenheit:
             if "cool" in target and target["cool"] is not None:
@@ -517,17 +530,23 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
                 target["heat"] = f_to_c(target["heat"])
 
         if "cool" in target:
-            response = self._pykumo.set_cool_setpoint(target["cool"])
+            response = await self.hass.async_add_executor_job(
+                self._pykumo.set_cool_setpoint, target["cool"]
+            )
             _LOGGER.debug(
                 "Kumo %s set %s temp response: %s", self._name, "cool", str(response)
             )
         if "heat" in target:
-            response = self._pykumo.set_heat_setpoint(target["heat"])
+            response = await self.hass.async_add_executor_job(
+                self._pykumo.set_heat_setpoint, target["heat"]
+            )
             _LOGGER.debug(
                 "Kumo %s set %s temp response: %s", self._name, "heat", str(response)
             )
 
-    def set_hvac_mode(self, hvac_mode, caller="set_hvac_mode"):
+        self.hass.async_create_task(self._delayed_refresh())
+
+    async def async_set_hvac_mode(self, hvac_mode, caller="async_set_hvac_mode"):
         """Set new target operation mode."""
         try:
             mode = HA_STATE_TO_KUMO[hvac_mode]
@@ -538,29 +557,36 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
             _LOGGER.warning("Kumo %s is not available", self._name)
             return
 
-        response = self._pykumo.set_mode(mode)
+        response = await self.hass.async_add_executor_job(self._pykumo.set_mode, mode)
         _LOGGER.debug(
             "Kumo %s set mode %s (via `%s`) response: %s", self._name, hvac_mode, caller, response
         )
+        self.hass.async_create_task(self._delayed_refresh())
 
-    def set_swing_mode(self, swing_mode):
+    async def async_set_swing_mode(self, swing_mode):
         """Set new vane swing mode."""
         if not self.available:
             _LOGGER.warning("Kumo %s is not available", self._name)
             return
 
-        response = self._pykumo.set_vane_direction(swing_mode)
+        response = await self.hass.async_add_executor_job(
+            self._pykumo.set_vane_direction, swing_mode
+        )
         _LOGGER.debug("Kumo %s set swing mode response: %s", self._name, response)
+        self.hass.async_create_task(self._delayed_refresh())
 
-    def set_fan_mode(self, fan_mode):
+    async def async_set_fan_mode(self, fan_mode):
         """Set new fan speed mode."""
         if not self.available:
             _LOGGER.warning("Kumo %s is not available", self._name)
             return
 
-        response = self._pykumo.set_fan_speed(fan_mode)
+        response = await self.hass.async_add_executor_job(
+            self._pykumo.set_fan_speed, fan_mode
+        )
         _LOGGER.debug("Kumo %s set fan speed response: %s", self._name, response)
+        self.hass.async_create_task(self._delayed_refresh())
 
-    def turn_off(self):
+    async def async_turn_off(self):
         """Turn the climate off. This implements https://www.home-assistant.io/integrations/climate/#action-climateturn_off."""
-        self.set_hvac_mode(HVACMode.OFF, caller="turn_off")
+        await self.async_set_hvac_mode(HVACMode.OFF, caller="async_turn_off")

--- a/custom_components/kumo/config_flow.py
+++ b/custom_components/kumo/config_flow.py
@@ -14,7 +14,15 @@ from homeassistant.helpers.json import save_json
 from pykumo import KumoCloudAccount
 from requests.exceptions import ConnectionError
 
-from .const import DHCP_DISCOVERED_KEY, DOMAIN, KUMO_CONFIG_CACHE
+from .const import (
+    CONF_CONNECT_TIMEOUT,
+    CONF_REFRESH_INTERVAL,
+    CONF_RESPONSE_TIMEOUT,
+    DEFAULT_REFRESH_INTERVAL,
+    DHCP_DISCOVERED_KEY,
+    DOMAIN,
+    KUMO_CONFIG_CACHE,
+)
 
 DEFAULT_PREFER_CACHE = False
 _LOGGER = logging.getLogger(__name__)
@@ -287,10 +295,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
+        current = self._config_entry.options
         data_schema = vol.Schema(
             {
-                vol.Required("connect_timeout", default=1.2): vol.Coerce(float),
-                vol.Required("response_timeout", default=8): vol.Coerce(float),
+                vol.Required(
+                    CONF_CONNECT_TIMEOUT,
+                    default=float(current.get(CONF_CONNECT_TIMEOUT, 1.2)),
+                ): vol.Coerce(float),
+                vol.Required(
+                    CONF_RESPONSE_TIMEOUT,
+                    default=float(current.get(CONF_RESPONSE_TIMEOUT, 8)),
+                ): vol.Coerce(float),
+                vol.Required(
+                    CONF_REFRESH_INTERVAL,
+                    default=float(current.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=30.0)),
             }
         )
 

--- a/custom_components/kumo/const.py
+++ b/custom_components/kumo/const.py
@@ -13,6 +13,8 @@ KUMO_CONFIG_CACHE = "kumo_cache.json"
 CONF_PREFER_CACHE = "prefer_cache"
 CONF_CONNECT_TIMEOUT = "connect_timeout"
 CONF_RESPONSE_TIMEOUT = "response_timeout"
+CONF_REFRESH_INTERVAL = "refresh_interval"
+DEFAULT_REFRESH_INTERVAL = 2.0  # seconds; delay before post-command coordinator refresh
 MAX_AVAILABILITY_TRIES = 3 # How many times we will attempt to update from a kumo before marking it unavailable
 
 DHCP_DISCOVERED_KEY = f"{DOMAIN}_dhcp_discovered"

--- a/custom_components/kumo/coordinator.py
+++ b/custom_components/kumo/coordinator.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
                                                       UpdateFailed)
@@ -24,9 +25,11 @@ class KumoDataUpdateCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         device: PyKumoBase,
+        config_entry: ConfigEntry | None = None,
     ) -> None:
         """Initialize DataUpdateCoordinator to gather data for specific Kumo device."""
         self.device = device
+        self._config_entry = config_entry
         self._available = False
         self._unavailable_count = 0
         self._additional_update_methods = []

--- a/custom_components/kumo/strings.json
+++ b/custom_components/kumo/strings.json
@@ -33,9 +33,11 @@
         }
       },
       "timeout_settings": {
+        "title": "Polling & Timing",
         "data": {
-          "connect_timeout": "Connection Timeout",
-          "response_timeout": "Response Timeout"
+          "connect_timeout": "Connection Timeout (seconds)",
+          "response_timeout": "Response Timeout (seconds)",
+          "refresh_interval": "Post-Command Refresh Delay (seconds, 0–30)"
         }
       },
       "unit_select": {

--- a/custom_components/kumo/translations/en.json
+++ b/custom_components/kumo/translations/en.json
@@ -33,9 +33,11 @@
         }
       },
       "timeout_settings": {
+        "title": "Polling & Timing",
         "data": {
-          "connect_timeout": "Connection Timeout",
-          "response_timeout": "Response Timeout"
+          "connect_timeout": "Connection Timeout (seconds)",
+          "response_timeout": "Response Timeout (seconds)",
+          "refresh_interval": "Post-Command Refresh Delay (seconds, 0–30)"
         }
       },
       "unit_select": {


### PR DESCRIPTION
## Summary

After issuing a set command (temperature, mode, fan, swing), pykumo's cached state continues to reflect the pre-command value until the next scheduled poll. On the default 60s poll interval this means HA shows stale state for up to a minute after a user command.

This PR adds a fire-and-forget `_delayed_refresh()` task that triggers the coordinator a short time after each command, so HA state reflects the new values much sooner without waiting for the next full poll cycle.

As part of this change, all set methods are converted from synchronous to `async_*`, with pykumo blocking calls wrapped in `hass.async_add_executor_job`. This prevents the blocking HTTP calls to the Kumo WiFi adapter from running on the HA event loop.

The refresh delay is configurable via **Settings → Integrations → Kumo → Configure → Polling & Timing → Post-Command Refresh Delay** (default: 2 seconds, range: 0–30). A reload is required after changing the value.

## Notes

- The 2s default reflects the observed latency for Kumo WiFi adapters to apply a command and reflect it on the next HTTP GET. This varies by unit — hence the user-configurable option.
- `_delayed_refresh` reads the delay from `coordinator._config_entry.options` at call time, so it always uses the currently configured value.

## Test plan

- [ ] Set temperature from HA UI and confirm state updates within ~2s rather than waiting for the next poll
- [ ] Set HVAC mode and confirm same
- [ ] Confirm no errors in HA log during or after set operations
- [ ] Confirm the Post-Command Refresh Delay option appears in the Kumo options flow and is respected