### PR TITLE
Make poll interval user-configurable via options flow

### DIFF
--- a/custom_components/kumo/__init__.py
+++ b/custom_components/kumo/__init__.py
@@ -1,5 +1,6 @@
 """Support for Mitsubishi KumoCloud devices."""
 import logging
+from datetime import timedelta
 from typing import Optional
 
 import homeassistant.helpers.config_validation as cv
@@ -16,6 +17,8 @@ from .const import (
     CONF_CONNECT_TIMEOUT,
     CONF_PREFER_CACHE,
     CONF_RESPONSE_TIMEOUT,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
     DHCP_DISCOVERED_KEY,
     DOMAIN,
     KUMO_CONFIG_CACHE,
@@ -99,10 +102,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             entry.options.get(CONF_RESPONSE_TIMEOUT, "8")
         )
         timeouts = (connect_timeout, response_timeout)
+        scan_interval_secs = float(entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+        update_interval = timedelta(seconds=scan_interval_secs)
         pykumos = await hass.async_add_executor_job(account.make_pykumos, timeouts, True)
         for device in pykumos.values():
             if device.get_serial() not in coordinators:
-                coordinators[device.get_serial()] = KumoDataUpdateCoordinator(hass, device)
+                coordinators[device.get_serial()] = KumoDataUpdateCoordinator(
+                    hass, device, update_interval=update_interval
+                )
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         return True

--- a/custom_components/kumo/config_flow.py
+++ b/custom_components/kumo/config_flow.py
@@ -14,7 +14,15 @@ from homeassistant.helpers.json import save_json
 from pykumo import KumoCloudAccount
 from requests.exceptions import ConnectionError
 
-from .const import DHCP_DISCOVERED_KEY, DOMAIN, KUMO_CONFIG_CACHE
+from .const import (
+    CONF_CONNECT_TIMEOUT,
+    CONF_RESPONSE_TIMEOUT,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DHCP_DISCOVERED_KEY,
+    DOMAIN,
+    KUMO_CONFIG_CACHE,
+)
 
 DEFAULT_PREFER_CACHE = False
 _LOGGER = logging.getLogger(__name__)
@@ -287,10 +295,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
+        current = self._config_entry.options
         data_schema = vol.Schema(
             {
-                vol.Required("connect_timeout", default=1.2): vol.Coerce(float),
-                vol.Required("response_timeout", default=8): vol.Coerce(float),
+                vol.Required(
+                    CONF_CONNECT_TIMEOUT,
+                    default=float(current.get(CONF_CONNECT_TIMEOUT, 1.2)),
+                ): vol.Coerce(float),
+                vol.Required(
+                    CONF_RESPONSE_TIMEOUT,
+                    default=float(current.get(CONF_RESPONSE_TIMEOUT, 8)),
+                ): vol.Coerce(float),
+                vol.Required(
+                    CONF_SCAN_INTERVAL,
+                    default=int(current.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),
+                ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
             }
         )
 

--- a/custom_components/kumo/const.py
+++ b/custom_components/kumo/const.py
@@ -13,10 +13,12 @@ KUMO_CONFIG_CACHE = "kumo_cache.json"
 CONF_PREFER_CACHE = "prefer_cache"
 CONF_CONNECT_TIMEOUT = "connect_timeout"
 CONF_RESPONSE_TIMEOUT = "response_timeout"
+CONF_SCAN_INTERVAL = "scan_interval"
+DEFAULT_SCAN_INTERVAL = 60  # seconds
 MAX_AVAILABILITY_TRIES = 3 # How many times we will attempt to update from a kumo before marking it unavailable
 
 DHCP_DISCOVERED_KEY = f"{DOMAIN}_dhcp_discovered"
 
 PLATFORMS: Final = [Platform.CLIMATE, Platform.SENSOR]
 
-SCAN_INTERVAL = timedelta(seconds=60)
+SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL)

--- a/custom_components/kumo/coordinator.py
+++ b/custom_components/kumo/coordinator.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from typing import TypeVar
 
 from homeassistant.core import HomeAssistant
@@ -24,6 +25,7 @@ class KumoDataUpdateCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         device: PyKumoBase,
+        update_interval: timedelta | None = None,
     ) -> None:
         """Initialize DataUpdateCoordinator to gather data for specific Kumo device."""
         self.device = device
@@ -34,7 +36,7 @@ class KumoDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"kumo_{device.get_serial()}",
-            update_interval=SCAN_INTERVAL,
+            update_interval=update_interval if update_interval is not None else SCAN_INTERVAL,
         )
 
     def get_device(self) -> PyKumoBase:

--- a/custom_components/kumo/strings.json
+++ b/custom_components/kumo/strings.json
@@ -33,9 +33,11 @@
         }
       },
       "timeout_settings": {
+        "title": "Polling & Timing",
         "data": {
-          "connect_timeout": "Connection Timeout",
-          "response_timeout": "Response Timeout"
+          "connect_timeout": "Connection Timeout (seconds)",
+          "response_timeout": "Response Timeout (seconds)",
+          "scan_interval": "Poll Interval (seconds, 5–300)"
         }
       },
       "unit_select": {

--- a/custom_components/kumo/translations/en.json
+++ b/custom_components/kumo/translations/en.json
@@ -33,9 +33,11 @@
         }
       },
       "timeout_settings": {
+        "title": "Polling & Timing",
         "data": {
-          "connect_timeout": "Connection Timeout",
-          "response_timeout": "Response Timeout"
+          "connect_timeout": "Connection Timeout (seconds)",
+          "response_timeout": "Response Timeout (seconds)",
+          "scan_interval": "Poll Interval (seconds, 5–300)"
         }
       },
       "unit_select": {


### PR DESCRIPTION
## Summary

`SCAN_INTERVAL` is currently hardcoded at 60 seconds with no way to adjust it without modifying source files. Users with fast local networks or wall thermostats that change setpoints independently of HA may want shorter intervals; users who want to reduce device load may want longer ones.

This PR adds `scan_interval` to the existing **Polling & Timing** options step, allowing users to set the poll interval between 5 and 300 seconds via **Settings → Integrations → Kumo → Configure → Polling & Timing → Poll Interval**.

The default remains 60s for backward compatibility. A reload is required after changing the value.

## Test plan

- [ ] Set poll interval to 30s, reload, and confirm coordinator fires roughly every 30s in the HA log
- [ ] Confirm the Poll Interval option appears in the Kumo options flow
- [ ] Confirm default of 60s applies on a fresh install with no options set