### PR TITLE
Addresses #120 by releasing old coordinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ By default a sensor for current temperature is enabled. It's possible to enable 
 
 To enable these optional sensors, click on the Kumo tile in Settings -> Devices and Services, go into the Devices section, click on the indoor unit (or Kumo Station) and enable them under Sensors.
 
-**Note** that you will need to restart HmomeAssistant after enabling a new sensor type, due to [Issue 120](https://github.com/dlarrick/hass-kumo/issues/120).
-
 ### Template Sensors
 
 For additional attributes not covered above, or if you require more customization, you can convert attributes to sensors using [templates](https://community.home-assistant.io/t/using-attributes-in-lovelace/72672). For example, here's a simple sensor for the target temperature.

--- a/custom_components/kumo/__init__.py
+++ b/custom_components/kumo/__init__.py
@@ -166,9 +166,13 @@ async def async_kumo_setup_v2(hass: HomeAssistant, prefer_cache: bool, username:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload Entry"""
 
+    all_ok = True
     for platform in PLATFORMS:
-        all_ok = True
         unload_ok = await hass.config_entries.async_forward_entry_unload(entry, platform)
         if not unload_ok:
             all_ok = False
+
+    if all_ok:
+        hass.data[DOMAIN][entry.entry_id].pop(KUMO_DATA_COORDINATORS, None)
+
     return all_ok


### PR DESCRIPTION
Home Assistant Core expects coordinators to be re-created from scratch on a config change. This change removes them in unload so they will be recreated on load.

Before this change, Core would mark the Debouncers in the coordinators as terminated. That led to later polls being silently dropped, and the DEBUG log lines.

Addresses #120 