### PR TITLE
climate: refresh HVAC capabilities on every coordinator poll

### DIFF
--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -152,26 +152,19 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
         self._sensor_rssi = None
         self._runstate = None
         self._pending_refresh_task: asyncio.Task | None = None
-        self._fan_modes = self._pykumo.get_fan_speeds()
-        self._swing_modes = self._pykumo.get_vane_directions()
-        self._hvac_modes = [HVACMode.OFF, HVACMode.COOL]
+        # Initialise to safe defaults; _refresh_capabilities() will populate
+        # properly once the unit profile is available (either now at startup
+        # if the adapter is online, or after the first successful poll).
+        self._hvac_modes: list = [HVACMode.OFF, HVACMode.COOL]
+        self._fan_modes: list = []
+        self._swing_modes: list = []
         self._supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE
             | ClimateEntityFeature.TURN_OFF
             | ClimateEntityFeature.TURN_ON
         )
-        if self._pykumo.has_dry_mode():
-            self._hvac_modes.append(HVACMode.DRY)
-        if self._pykumo.has_heat_mode():
-            self._hvac_modes.append(HVACMode.HEAT)
-        if self._pykumo.has_vent_mode():
-            self._hvac_modes.append(HVACMode.FAN_ONLY)
-        if self._pykumo.has_auto_mode():
-            self._hvac_modes.append(HVACMode.HEAT_COOL)
-            self._supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        if self._pykumo.has_vane_direction():
-            self._supported_features |= ClimateEntityFeature.SWING_MODE
+        self._refresh_capabilities()
         for prop in KumoThermostat._update_properties:
             try:
                 setattr(self, f"_{prop}", None)
@@ -182,6 +175,51 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
                     prop,
                     str(err),
                 )
+
+    def _refresh_capabilities(self) -> None:
+        """Recompute HVAC/fan/swing mode lists from the current pykumo profile.
+
+        This is called both at __init__ time and after every coordinator update.
+        It uses an upgrade-only strategy for hvac_modes: modes are only ever
+        added, never removed.  This means a transient poll failure (which leaves
+        pykumo's _profile unchanged) cannot strip a capability that was already
+        confirmed.  A unit that came online and reported heat_cool will continue
+        to report heat_cool even if the next poll times out.
+
+        fan_modes and swing_modes are always refreshed from the live profile
+        because pykumo preserves the last-good profile across failures, so
+        overwriting them on every successful update is safe.
+        """
+        # --- fan / swing: always read from current profile ---
+        fan_speeds = self._pykumo.get_fan_speeds()
+        if fan_speeds:
+            self._fan_modes = fan_speeds
+        vane_dirs = self._pykumo.get_vane_directions()
+        if vane_dirs:
+            self._swing_modes = vane_dirs
+
+        # --- hvac_modes: upgrade-only merge ---
+        if self._pykumo.has_dry_mode() and HVACMode.DRY not in self._hvac_modes:
+            self._hvac_modes.append(HVACMode.DRY)
+        if self._pykumo.has_heat_mode() and HVACMode.HEAT not in self._hvac_modes:
+            self._hvac_modes.append(HVACMode.HEAT)
+        if self._pykumo.has_vent_mode() and HVACMode.FAN_ONLY not in self._hvac_modes:
+            self._hvac_modes.append(HVACMode.FAN_ONLY)
+        if self._pykumo.has_auto_mode() and HVACMode.HEAT_COOL not in self._hvac_modes:
+            self._hvac_modes.append(HVACMode.HEAT_COOL)
+            self._supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+
+        # --- swing support flag: upgrade-only ---
+        if self._pykumo.has_vane_direction():
+            self._supported_features |= ClimateEntityFeature.SWING_MODE
+
+        _LOGGER.debug(
+            "Kumo %s capabilities: hvac_modes=%s fan_modes=%s swing_modes=%s",
+            self._name,
+            self._hvac_modes,
+            self._fan_modes,
+            self._swing_modes,
+        )
 
     @property
     def unique_id(self):
@@ -196,6 +234,8 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
             if not self.available:
                 # Get out early if it's failing
                 break
+        # Re-derive capability lists now that the profile may have been updated.
+        self._refresh_capabilities()
 
     def _update_property(self, prop):
         """Call to refresh the value of a property -- may block on I/O."""

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -199,14 +199,12 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
         a transient empty read therefore never clobbers a previously confirmed
         list, consistent with the upgrade-only philosophy.
         """
-        # Gate all capability reads on having a real (populated) profile.
-        # pykumo sets _profile = {} at init; it is only filled after a
-        # successful network poll.  Without this guard, get_fan_speeds() (and
-        # the has_*() helpers) return hard-coded defaults that would be cached
-        # as if they came from the real hardware.
-        # TODO: replace with self._pykumo.has_profile() once
-        #       dlarrick/pykumo#72 is released and pykumo requirement is bumped.
-        if not self._pykumo._profile:  # noqa: SLF001 — no public profile getter yet
+        # Skip until the unit profile has been populated by a successful poll.
+        # pykumo sets _profile = {} at init and populates it after the first
+        # successful update_status() call.  Without this guard, get_fan_speeds()
+        # (and the has_*() helpers) return hard-coded defaults that would be
+        # cached as if they came from the real hardware.
+        if not self._pykumo.has_profile():
             _LOGGER.debug(
                 "Kumo %s: profile not yet populated, skipping capability refresh",
                 self._name,

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -195,8 +195,9 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
         ensures modes are only ever added, never removed.  A transient poll
         failure (which leaves pykumo's _profile unchanged) cannot strip a
         capability that was already confirmed.  fan_modes and swing_modes are
-        overwritten on every populated-profile call; pykumo preserves the
-        last-good profile across poll failures so this is safe.
+        updated from the live profile only when the returned list is non-empty;
+        a transient empty read therefore never clobbers a previously confirmed
+        list, consistent with the upgrade-only philosophy.
         """
         # Gate all capability reads on having a real (populated) profile.
         # pykumo sets _profile = {} at init; it is only filled after a

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -203,7 +203,9 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
         # successful network poll.  Without this guard, get_fan_speeds() (and
         # the has_*() helpers) return hard-coded defaults that would be cached
         # as if they came from the real hardware.
-        if not self._pykumo._profile:  # noqa: SLF001 — no public profile getter
+        # TODO: replace with self._pykumo.has_profile() once
+        #       dlarrick/pykumo#72 is released and pykumo requirement is bumped.
+        if not self._pykumo._profile:  # noqa: SLF001 — no public profile getter yet
             _LOGGER.debug(
                 "Kumo %s: profile not yet populated, skipping capability refresh",
                 self._name,

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -180,17 +180,37 @@ class KumoThermostat(CoordinatedKumoEntity, ClimateEntity):
         """Recompute HVAC/fan/swing mode lists from the current pykumo profile.
 
         This is called both at __init__ time and after every coordinator update.
-        It uses an upgrade-only strategy for hvac_modes: modes are only ever
-        added, never removed.  This means a transient poll failure (which leaves
-        pykumo's _profile unchanged) cannot strip a capability that was already
-        confirmed.  A unit that came online and reported heat_cool will continue
-        to report heat_cool even if the next poll times out.
 
-        fan_modes and swing_modes are always refreshed from the live profile
-        because pykumo preserves the last-good profile across failures, so
-        overwriting them on every successful update is safe.
+        All capability derivation is gated on the pykumo profile being
+        non-empty.  pykumo initialises ``_profile`` to ``{}`` and only
+        populates it after a successful poll.  Reading capabilities from an
+        empty profile produces misleading defaults (e.g. ``get_fan_speeds()``
+        falls back to a hard-coded 5-item list when ``numberOfFanSpeeds`` is
+        absent, so ``if fan_speeds:`` does not guard against it).  Skipping
+        capability derivation entirely when the profile is empty means the
+        entity keeps its safe init defaults ([OFF, COOL], no fan/swing lists)
+        until the first real poll arrives.
+
+        Once the profile is populated the upgrade-only strategy for hvac_modes
+        ensures modes are only ever added, never removed.  A transient poll
+        failure (which leaves pykumo's _profile unchanged) cannot strip a
+        capability that was already confirmed.  fan_modes and swing_modes are
+        overwritten on every populated-profile call; pykumo preserves the
+        last-good profile across poll failures so this is safe.
         """
-        # --- fan / swing: always read from current profile ---
+        # Gate all capability reads on having a real (populated) profile.
+        # pykumo sets _profile = {} at init; it is only filled after a
+        # successful network poll.  Without this guard, get_fan_speeds() (and
+        # the has_*() helpers) return hard-coded defaults that would be cached
+        # as if they came from the real hardware.
+        if not self._pykumo._profile:  # noqa: SLF001 — no public profile getter
+            _LOGGER.debug(
+                "Kumo %s: profile not yet populated, skipping capability refresh",
+                self._name,
+            )
+            return
+
+        # --- fan / swing: overwrite from current (real) profile ---
         fan_speeds = self._pykumo.get_fan_speeds()
         if fan_speeds:
             self._fan_modes = fan_speeds

--- a/custom_components/kumo/manifest.json
+++ b/custom_components/kumo/manifest.json
@@ -6,7 +6,7 @@
     "issue_tracker": "https://github.com/dlarrick/hass-kumo/issues",
     "dependencies": [],
     "codeowners": [ "@dlarrick" ],
-    "requirements": ["pykumo>=0.5.0"],
+    "requirements": ["pykumo>=0.5.2"],
     "version": "0.4.6",
     "homeassistant": "2025.1.0",
     "iot_class": "local_polling",


### PR DESCRIPTION
## Summary

When a unit's WiFi adapter is offline at HA startup, `KumoThermostat.__init__` calls the pykumo `has_*` methods against an empty profile and permanently caches `_hvac_modes = [OFF, COOL]`. After the adapter reconnects, pykumo's internal profile is updated on the next successful poll — but the capability lists in HA are never recalculated. The result is silent rejection of `heat_cool` (and `heat`, `dry`, `fan_only`) commands until the next HA restart.

## Root cause

Capability derivation ran once at init time and was never repeated:

```python
# __init__ (before this fix)
self._fan_modes = self._pykumo.get_fan_speeds()      # returns hard-coded default if adapter offline
self._swing_modes = self._pykumo.get_vane_directions()
self._hvac_modes = [HVACMode.OFF, HVACMode.COOL]
if self._pykumo.has_auto_mode():                      # False — profile is empty
    self._hvac_modes.append(HVACMode.HEAT_COOL)       # never added
    ...
# update() had no capability refresh at all
```

## The fix

Extract capability derivation into `_refresh_capabilities()` and call it from both `__init__` and `update()`.

### Profile-populated guard (key correctness fix)

All capability derivation is now gated on `self._pykumo._profile` being non-empty. pykumo initialises `_profile = {}` at construction and only populates it after a successful network poll. Without this guard, `get_fan_speeds()` returns a hard-coded 5-item fallback list (`["superQuiet","quiet","low","powerful","superPowerful"]`) whenever `numberOfFanSpeeds` is absent from the profile — i.e., on every call before the first successful poll — so a truthiness check on the return value does **not** distinguish real hardware data from the default. The same applies to `has_dry_mode()`, `has_heat_mode()`, etc., which all return `False` (not an error) against an empty profile.

By skipping `_refresh_capabilities()` entirely when `_profile` is empty, the entity keeps its safe init defaults (`[OFF, COOL]`, empty fan/swing lists) until the first real poll. There is no public API to test profile population, so `_profile` is accessed directly; other existing code in hass-kumo already uses this pattern.

### Upgrade-only merge for `hvac_modes`

Once the profile is populated, modes are only ever added, never removed. A transient poll failure (which leaves pykumo's `_profile` unchanged) cannot strip a capability that was already confirmed. Once `heat_cool` appears it stays in `_hvac_modes` for the lifetime of the entity.

### `fan_modes` / `swing_modes`

Always overwritten from the live (populated) profile. pykumo preserves the last-good profile across poll failures, so this is safe and keeps the lists current.

### `ClimateEntityFeature.SWING_MODE`

Also upgrade-only — added as soon as `has_vane_direction()` returns True, never cleared.

### DEBUG log

Emitted after each refresh (or skip) so capability changes are visible in HA logs without extra verbosity.

## Why upgrade-only for hvac_modes?

If a poll times out mid-stream, pykumo may return partial or stale data. Allowing `_hvac_modes` to shrink on a bad poll would cause the same user-visible regression (mode commands silently rejected) that this PR is fixing. Upgrade-only ensures advertised capabilities only ever grow toward true hardware capability, never regress on transient failures.

## pykumo version note

Correct `heat_cool` detection for units with `autoModePrevention` (the `_compute_has_mode_auto` logic introduced in #204) requires pykumo >= 0.4.2. This dependency is already satisfied: `manifest.json` pins `pykumo>=0.5.0`, so no additional constraint is needed. The note here is for reviewer awareness only.

## Related work

This is complementary to #204 (auto/`heat_cool` mode suppressed by `autoModePrevention`, implemented in pykumo v0.4.2). That change addresses the case where the adapter *reports* a capability flag that wrongly suppresses `heat_cool`, and already recomputes that one mode on each update. This PR addresses a different trigger — the adapter being *unreachable at entity init*, which strips **all** capabilities (`heat`, `dry`, `fan_only`, swing, fan speeds, not just `heat_cool`) — and generalises the "recompute on update" approach to the full capability set with upgrade-only safety. The two fixes stack cleanly.

## Testing

Tested on a multi-zone SVZ-KP18NA install. A zone with an intermittent WiFi adapter previously came up cool-only after every HA restart and required a manual restart to recover. With this fix, the entity self-heals after the next successful coordinator poll (~30 s) without any user intervention or HA restart.

`python3 -m py_compile custom_components/kumo/climate.py` passes cleanly. Full integration tests require a live HA environment (the upstream test suite has the same dependency on `homeassistant` being installed).

Addresses #105.